### PR TITLE
Validate feedback rating range

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,19 @@ const express = require('express');
 
 const app = express();
 
+app.use(express.json());
+
 app.get('/', (req, res) => {
   res.json({ ok: true });
+});
+
+app.post('/stories/:id/feedback', (req, res) => {
+  const { rating } = req.body;
+  const numericRating = Number(rating);
+  if (!Number.isFinite(numericRating) || numericRating < 1 || numericRating > 5) {
+    return res.status(400).json({ error: 'Invalid rating' });
+  }
+  res.status(200).json({ ok: true });
 });
 
 // Only start the server when not running tests

--- a/tests/stories.test.js
+++ b/tests/stories.test.js
@@ -1,0 +1,31 @@
+process.env.NODE_ENV = 'test';
+
+const http = require('http');
+const request = require('supertest');
+const app = require('../index.js');
+
+let server;
+
+beforeAll(() => {
+  server = http.createServer(app).listen(0);
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe('POST /stories/:id/feedback validation', () => {
+  test('rejects rating outside 1-5', async () => {
+    const res = await request(server)
+      .post('/stories/123/feedback')
+      .send({ rating: 10 });
+    expect(res.status).toBe(400);
+  });
+
+  test('rejects non-numeric rating', async () => {
+    const res = await request(server)
+      .post('/stories/123/feedback')
+      .send({ rating: 'bad' });
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- validate `/stories/:id/feedback` rating is numeric and within 1-5, returning 400 otherwise
- cover invalid rating scenarios with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcae5365f08331927a3921618760a3